### PR TITLE
Fix race condition in stack allocator

### DIFF
--- a/src/memory/stackallocator.c
+++ b/src/memory/stackallocator.c
@@ -113,8 +113,6 @@ void StackAllocatorFree(void* ptr)
     if (A.debug)
     {
         u64 dealloc_size = (u8*)A.top - (u8*)ptr + sizeof(A.separator);
-        // Mark freed memory
-        memset((u8*)ptr - sizeof(A.separator), UNALLOC_BYTE, dealloc_size);
         for (i32 i = A.allocations_num - 1; i >= 0; i--)
         {
             A.allocations_num--;
@@ -122,6 +120,9 @@ void StackAllocatorFree(void* ptr)
                 break;
         }
         *((u32*)ptr)--; // Move the ptr to point at the separator before freeing
+
+        // Mark freed memory
+        memset((u8*)ptr - sizeof(A.separator), UNALLOC_BYTE, dealloc_size);
     }
 
     if (ptr < A.top)

--- a/src/memory/stackallocator.c
+++ b/src/memory/stackallocator.c
@@ -122,7 +122,7 @@ void StackAllocatorFree(void* ptr)
         *((u32*)ptr)--; // Move the ptr to point at the separator before freeing
 
         // Mark freed memory
-        memset((u8*)ptr - sizeof(A.separator), UNALLOC_BYTE, dealloc_size);
+        memset((u8*)ptr, UNALLOC_BYTE, dealloc_size);
     }
 
     if (ptr < A.top)


### PR DESCRIPTION
When freeing memory stack allocator sets all bytes (including the separator) to UNALLOC_BYTE. At the same time watchdog may check whether the separator is equal to 0x00FACADE and fail. The solution is to move the memset invocation after the loop, which decreases allocations_num. At this point allocations are already freed and the watchdog will not check them, so we may safely reset the memory.