### PR TITLE
Implement a recording system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
     renderer/i3integration.c
     renderer/imfont_storage.c
     renderer/vkhelper.c
+    replay.c
     script/scripting.c
     script/scriptreg.c
     script/imgui_lua.cpp

--- a/src/culibc.c
+++ b/src/culibc.c
@@ -60,6 +60,11 @@ void cu_memset(void* dst, int c, size_t len)
     SDL_memset(dst, c, len);
 }
 
+void cu_memcpy(void* dst, void* src, size_t len)
+{
+    SDL_memcpy(dst, src, len);
+}
+
 char* cu_getcwd()
 {
     return SDL_GetBasePath();

--- a/src/culibc.h
+++ b/src/culibc.h
@@ -13,5 +13,6 @@ size_t cu_strcmp(const char* str1, const char* str2);
 size_t cu_strlcpy(char* dst, const char* src, size_t max_len);
 size_t cu_strlcat(char* dst, const char* src, size_t max_len);
 void cu_memset(void* dst, int c, size_t len);
+void cu_memcpy(void* dst, void* src, size_t len);
 char* cu_getcwd();
 void cu_freecwdptr();

--- a/src/entity.c
+++ b/src/entity.c
@@ -17,8 +17,8 @@ static void UpdateFreeFlyingCameraRotation(Entity* camera)
 {
     static const f32 max_pitch =  0.5f * PI - 0.017f;
     static const f32 min_pitch = -0.5f * PI + 0.017f;
-    static f32 yaw = (3.0f / 2.0f) * PI;
-    static f32 pitch = 0.0f;
+    f32 yaw = camera->rotation.yaw;
+    f32 pitch = camera->rotation.pitch;
 
     v2 delta = GetMouseDelta();
 
@@ -34,6 +34,8 @@ static void UpdateFreeFlyingCameraRotation(Entity* camera)
     forward.z = cosf(pitch) * sinf(yaw);
 
     camera->direction = V3Normalize(forward);
+    camera->rotation.yaw = yaw;
+    camera->rotation.pitch = pitch;
 }
 
 static void UpdateFreeFlyingCameraPosition(Entity* camera, f32 delta)
@@ -55,8 +57,7 @@ static void UpdateFreeFlyingCameraPosition(Entity* camera, f32 delta)
         *position = V3Subtract(*position, V3Mul(velocity, right));
     else if (GetKeyState(KEY_D) & KEY_STATE_DOWN)
         *position = V3Add(*position, V3Mul(velocity, right));
-    if (GetKeyState(KEY_Q) & KEY_STATE_DOWN
-     || GetKeyState(KEY_CTRL) & KEY_STATE_DOWN)
+    if (GetKeyState(KEY_Q) & KEY_STATE_DOWN)
         *position = V3Subtract(*position, V3Mul(velocity, up));
     else if (GetKeyState(KEY_E) & KEY_STATE_DOWN
           || GetKeyState(KEY_SPACE) & KEY_STATE_DOWN)
@@ -76,6 +77,10 @@ Entity CreateFreeFlyingCameraEntity(v3 pos)
         .position = pos,
         .direction = v3(0.0f, 0.0f, -1.0f),
         .velocity = v3(0.0005f, 0.0005f, 0.0005f),
+        .rotation = {
+            .yaw = (3.0f / 2.0f) * PI,
+            .pitch = 0.0f
+        }
     };
 
     return e;

--- a/src/entity.h
+++ b/src/entity.h
@@ -19,6 +19,17 @@ typedef struct Entity
     v3 velocity;
     v3 direction;
     v3 target;
+
+    union euler
+    {
+        v3 angles;
+        struct
+        {
+            f32 yaw;
+            f32 pitch;
+            f32 roll;
+        };
+    } rotation;
 } Entity;
 
 Entity CreateFreeFlyingCameraEntity(v3 pos);

--- a/src/file.h
+++ b/src/file.h
@@ -12,17 +12,44 @@ typedef struct File
     b8 valid;
 } File;
 
-
+// Opens file handle with one of the following modes:
+// "r" - open for reading
+// "w" - open for writing
+// "a" - open for appending
+// "rb" - open for reading in binary mode
+// "wb" - open for writing in binary mode
+// "ab" - open for appending in binary mode
+// Returns a file handle structure indicating if the operation was successful
+// using a valid field set to 1 and non-null error_msg when valid is set to 0.
 File FileOpen(const char* file, const char* mode);
+
+// Returns number of bytes read. Returns 0 if end of stream is encountered
 u64 FileRead(File* file, void *buffer, u64 obj_size, u64 obj_num);
+
+// FileWrite* functionsReturns number of bytes written.
 u64 FileWrite(File* file, void *buffer, u64 obj_size, u64 obj_num);
 u64 FileWriteStr(File* file, const char* string);
 u64 FileWriteStrf(File* file, const char* fmt, ...);
 u64 FileWriteStrfv(File* file, const char* fmt, va_list args);
 u64 FileWriteLine(File* file, const char* string);
 u64 FileWriteLinef(File* file, const char* fmt, ...);
+
+// This function seeks to byte offset, relative to whence. whence may be any of
+// the following values:
+// - RW_SEEK_SET: seek from the beginning of data
+// - RW_SEEK_CUR: seek relative to current read point
+// - RW_SEEK_END: seek relative to the end of data
+// If this stream can not seek, it will return -1.
 s64 FileSeek(File* file, s64 offset, int whence);
+
+// Determine the current read/write offset in a file
 s64 FileTell(File* file);
+
+// Closes file handle
 i32 FileClose(File* file);
+
+// Returns file size or -1 on failure
 s64 FileSize(File* file);
+
+// Allocate a buffer and load file contents into a CString
 char* CStringFromFile(Arena* arena, const char* file);

--- a/src/input.h
+++ b/src/input.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "buffer.h"
 #include "types.h"
 #include "math/vec.h"
 
@@ -121,6 +122,8 @@ KeyStateBit GetMouseButtonState(u8 id);
 v2 GetMousePosition(void);
 v2 GetMouseDelta(void);
 void ResetInput(void);
+void ResetInputTo(KeyStateBit state);
 void SnapCursorToCenter(b8 enabled);
+Buffer GetInputState(void);
 
 void DEBUG_GamepadInput(void);

--- a/src/memory/arena.c
+++ b/src/memory/arena.c
@@ -109,6 +109,12 @@ void ArenaReset(Arena* arena)
     ArenaPopTo(arena, 0);
 }
 
+void ArenaResize(Arena* arena, u64 size)
+{
+    if (size > arena->size)
+        ArenaPush(arena, size - arena->pos);
+}
+
 ArenaMarker ArenaMarkerCreate(Arena* arena)
 {
     ArenaMarker marker = {arena, arena->pos};

--- a/src/memory/arena.h
+++ b/src/memory/arena.h
@@ -47,6 +47,7 @@ void ArenaShutdown(Arena* arena);
 void ArenaPopTo(Arena* arena, u64 pos);
 void ArenaPop(Arena* arena, u64 size);
 void ArenaReset(Arena* arena);
+void ArenaResize(Arena* arena, u64 size);
 
 // Internal API
 void* ArenaPushNoZero(Arena* arena, u64 size);

--- a/src/replay.c
+++ b/src/replay.c
@@ -1,0 +1,224 @@
+#include "replay.h"
+#include "culibc.h"
+#include "file.h"
+#include "input.h"
+#include "log/log.h"
+#include <cimgui.h>
+#include <assert.h>
+#include <math.h>
+
+static struct
+{
+    Arena* arenas[REPLAY_ARENAS_NUM];
+
+    ReplayBuffer* replay_buffers;
+    s8 recording_index;
+    s8 playback_index;
+
+    b8 playing;
+    b8 looping;
+
+    const Key bindings[4];
+} C = {
+    .bindings = { KEY_F5, KEY_F6, KEY_F7, KEY_F8 },
+    .recording_index = -1,
+    .playback_index = -1,
+};
+
+static void DrawReplayText(const char* text)
+{
+    // Blink
+    if ((int)(fmod(igGetTime(), 1.0) * 2) == 0)
+        return;
+
+    ImVec4 colour = { 1, 0, 0, 1 };
+    ImVec2 pos, size, dummy = {0};
+    igGetWindowSize(&pos);
+    pos.x = 0;
+    pos.y = 2 * pos.y - 70.0f;
+    igCalcTextSize(&size, text, NULL, false, -1);
+    size.x += 10.0f; // Somehow its still too narrow
+    igSetNextWindowPos(pos, 0, dummy);
+    igSetNextWindowSize(size, 0);
+
+    int flags = 0;
+    flags |= ImGuiWindowFlags_NoTitleBar;
+    flags |= ImGuiWindowFlags_NoResize;
+    flags |= ImGuiWindowFlags_NoMove;
+    flags |= ImGuiWindowFlags_NoScrollbar;
+    igBegin("Playback", NULL, flags);
+    igTextColored(colour, text);
+    igEnd();
+}
+
+static ReplayBuffer* GetReplayBuffer(s8 index)
+{
+    assert(index >= 0);
+    assert(index < REPLAY_BUFFER_NUM);
+    return &C.replay_buffers[index];
+}
+
+static void BeginRecordingInput(s8 recording_index)
+{
+    ReplayBuffer* replay_buffer = GetReplayBuffer(recording_index);
+    C.recording_index = recording_index;
+    C.playback_index = -1;
+    
+    File file = FileOpen(replay_buffer->name, "wb");
+    replay_buffer->file = file;
+
+    // Dump current game state
+    // Write size of arena in bytes as the first u64 before storing its memory
+    for (u8 i = 0; i < REPLAY_ARENAS_NUM; i++)
+    {
+        Arena* arena = C.arenas[i];
+        FileWrite(&file, arena, sizeof(Arena), 1);
+        FileWrite(&file, arena->base, arena->size, 1);
+    }
+
+    L_INFO("Recording to %s", replay_buffer->name);
+}
+
+static void EndRecordingInput(s8 recording_index)
+{
+    ReplayBuffer* replay_buffer = GetReplayBuffer(recording_index);
+    // Save file, disable recording
+    FileClose(&replay_buffer->file);
+    C.recording_index = -1;
+
+    L_INFO("Finished recording to %s", replay_buffer->name);
+}
+
+static void RecordInput(s8 recording_index)
+{
+    ReplayBuffer* replay_buffer = GetReplayBuffer(recording_index);
+
+    // Fetch Input
+    Buffer buffer = GetInputState();
+    // Save to file
+    FileWrite(&replay_buffer->file, buffer.ptr, buffer.length, 1);
+
+    DrawReplayText("¤ Recording");
+}
+
+static void BeginInputPlayback(s8 playback_index, b8 looping)
+{
+    ReplayBuffer* replay_buffer = GetReplayBuffer(playback_index);
+    C.recording_index = -1;
+    C.playback_index = playback_index;
+    
+    File file = FileOpen(replay_buffer->name, "rb");
+    if (!file.valid)
+    {
+        C.playback_index = -1;
+        L_ERROR("Error opening %s: %s", replay_buffer->name, file.error_msg);
+        return;
+    }
+
+    replay_buffer->file = file;
+
+    // Dump current game state
+    for (u8 i = 0; i < REPLAY_ARENAS_NUM; i++)
+    {
+        Arena* arena = C.arenas[i];
+        Arena serialised_arena = {0};
+        FileRead(&file, &serialised_arena, sizeof(Arena), 1);
+        // If arena requires more than the initial size, alloc enough before copy
+        if (serialised_arena.size > arena->size)
+            ArenaResize(arena, serialised_arena.size);
+        cu_memcpy(arena, &serialised_arena, sizeof(Arena));
+        FileRead(&file, arena->base, arena->size, 1);
+    }
+
+    C.playing = true;
+    if (!C.looping)
+        L_INFO("Running playback from %s", replay_buffer->name);
+    C.looping = looping;
+}
+
+static void PlaybackInput(s8 playback_index)
+{
+    ReplayBuffer* replay_buffer = GetReplayBuffer(playback_index);
+    Buffer buffer = GetInputState();
+
+    // Read input from file and overwrite it
+    if (FileRead(&replay_buffer->file, buffer.ptr, buffer.length, 1) == 0)
+    {
+        // End playback
+        C.playing = false;
+    }
+
+    DrawReplayText("» Playback");
+}
+
+static void EndInputPlayback(s8 playback_index)
+{
+    ReplayBuffer* replay_buffer = GetReplayBuffer(playback_index);
+    FileClose(&replay_buffer->file);
+    if (C.looping)
+    {
+        BeginInputPlayback(playback_index, true);
+    }
+    else
+    {
+        C.playing = false;
+        C.playback_index = -1;
+        ResetInputTo(KEY_STATE_UP); // Ctrl from recorded input may not be cleared
+
+        L_INFO("Finished playback from %s", replay_buffer->name);
+    }
+}
+
+void InitReplaySystem(ReplaySystemInitInfo* info)
+{
+    C.replay_buffers = info->replay_buffers;
+    cu_memcpy(C.arenas, info->arenas, sizeof(Arena*) * REPLAY_ARENAS_NUM);
+
+    for (s8 i = 0; i < REPLAY_BUFFER_NUM; i++)
+    {
+        cu_snprintf(C.replay_buffers[i].name, REPLAY_BUFFER_NAME_SIZE,
+            "Playback%02d.cpf", i + 1);
+    }
+}
+
+void UpdateReplaySystem()
+{
+    for (s8 i = 0; i < REPLAY_BUFFER_NUM; i++)
+    {
+        b8 ctrl = GetKeyState(KEY_CTRL) & KEY_STATE_DOWN;
+        b8 shift = GetKeyState(KEY_SHIFT) & KEY_STATE_DOWN;
+        b8 fx = GetKeyState(C.bindings[i]) & KEY_STATE_PRESSED;
+
+        if (ctrl && fx && !C.playing)
+        {
+            if (C.recording_index == -1)
+                BeginRecordingInput(i);
+            else if (C.recording_index == i)
+                EndRecordingInput(i);
+        }
+        else if (fx && C.recording_index == -1)
+        {
+            if (C.playback_index == -1)
+                BeginInputPlayback(i, !shift);
+            else if (C.playback_index == i)
+            {
+                C.looping = false;
+                EndInputPlayback(i);
+            }
+        }
+    }
+
+    if (C.recording_index != -1)
+    {
+        RecordInput(C.recording_index);
+    }
+
+    if (C.playback_index != -1)
+    {
+        PlaybackInput(C.playback_index);
+        if (!C.playing)
+        {
+            EndInputPlayback(C.playback_index);
+        }
+    }
+}

--- a/src/replay.h
+++ b/src/replay.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "file.h"
+#include "memory/arena.h"
+
+#define REPLAY_BUFFER_NAME_SIZE sizeof("PlaybackXX.cpf")
+#define REPLAY_BUFFER_NUM 4
+#define REPLAY_ARENAS_NUM 3
+
+typedef struct ReplayBuffer
+{
+    char name[REPLAY_BUFFER_NAME_SIZE];
+    File file;
+} ReplayBuffer;
+
+typedef struct ReplaySystemInitInfo
+{
+    Arena* arenas[REPLAY_ARENAS_NUM];
+    ReplayBuffer* replay_buffers;
+} ReplaySystemInitInfo;
+
+void InitReplaySystem(ReplaySystemInitInfo* info);
+void UpdateReplaySystem();

--- a/src/ui/scripteditor.cpp
+++ b/src/ui/scripteditor.cpp
@@ -263,7 +263,7 @@ static void HandleKeyboardInputs()
         NewFile();
     else if (ctrl && shift && ImGui::IsKeyPressed(ImGuiKey_R))
         OpenFile(C.recovery_file_name);
-    else if (ImGui::IsKeyPressed(ImGuiKey_F5))
+    else if (isAltOnly && ImGui::IsKeyPressed(ImGuiKey_F5))
         Execute();
     else if (ImGui::IsKeyPressed(ImGuiKey_F1))
         ShowHelp();


### PR DESCRIPTION
This feature introduces a debugging utility that allows user to record game replays. There are currently 4 replay slots.

To record a replay press `CTRL+F5/F6/F7/F8`.
To play it in loop simply press `F5/F6/F7/F8`. For playing just once, invoke with `SHIFT` held down.

When the recording starts, it saves current state of the game, followed by a number of per-frame keyboard and mouse inputs (whole input state in fact). The state is saved by serialising data of 3 arenas - permament storage, as well as 2 frame buffer arenas.

When a playback is invoked, the system reads Arenas metadata and resizes currently existing arenas appropriately, as to ensure that the system has given us an expected amount of commited pages to write to. Afterwards the arena metadata can be copied from the serialised file, as well as its memory contents. Then it starts streaming the input in.

Other fixes:
- Camera warping has been fixed
- File.h utility is now documented
- Vk renderer now has its own arena (to separate it from serialisable content)
- Execute lua script key binding has been now changed to `ALT+F5` (previously just `F5`)