### PR TITLE
Implement Save/Load systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SOURCES
     renderer/imfont_storage.c
     renderer/vkhelper.c
     replay.c
+    save.c
     script/scripting.c
     script/scriptreg.c
     script/imgui_lua.cpp

--- a/src/app.c
+++ b/src/app.c
@@ -15,6 +15,7 @@
 #include "platform.h"
 #include "replay.h"
 #include "renderer/renderer.h"
+#include "save.h"
 #include "script/scripting.h"
 #include "timer.h"
 #include "window.h"
@@ -118,6 +119,22 @@ static int InitReplaySystemInfo(void)
     return CU_SUCCESS;
 }
 
+static int InitSaveSystemInfo(void)
+{
+    SaveSystemInitInfo info = {
+        .arenas = {
+            &g_app.perm_storage_arena,
+            &g_app.frame_arenas[0],
+            &g_app.frame_arenas[1]
+        },
+    };
+
+    InitSaveSystem(&info);
+    L_INFO("Save system initialized");
+
+    return CU_SUCCESS;
+}
+
 static int InitWindow(void)
 {
     WindowResult window_result = CreateWindow(1024, 768, "Cubana");
@@ -161,6 +178,7 @@ static int Init(int argc, char* argv[])
     ReturnOnFailure(InitConfig(argc, argv));
     ReturnOnFailure(InitArenas());
     ReturnOnFailure(InitReplaySystemInfo());
+    ReturnOnFailure(InitSaveSystemInfo())
     ReturnOnFailure(InitWindow());
     ReturnOnFailure(InitRenderer());
     ReturnOnFailure(ScriptEngineInit());
@@ -219,6 +237,7 @@ static int AppLoop(void)
         f32 delta = GetTimeDelta();
         Arena* frame_arena = GetCurrentFrameArena();
         UpdateReplaySystem();
+        UpdateSaveSystem();
         DrawPerformanceStatistics(delta);
         EmitEvent(CreateEventTick(delta));
         PropagateEvents();

--- a/src/save.c
+++ b/src/save.c
@@ -1,0 +1,78 @@
+#include "save.h"
+#include "culibc.h"
+#include "file.h"
+#include "input.h"
+#include "log/log.h"
+#include <assert.h>
+
+static struct
+{
+    Arena* arenas[SAVE_ARENAS_NUM];
+} C;
+
+void InitSaveSystem(SaveSystemInitInfo* info)
+{
+    cu_memcpy(C.arenas, info->arenas, sizeof(Arena*) * SAVE_ARENAS_NUM);
+}
+
+b8 SaveGameState(const char* filename)
+{
+    File file = FileOpen(filename, "wb");
+    if (!file.valid)
+    {
+        L_ERROR("Failed to open %s for saving", filename);
+        return false;
+    }
+
+    for (u8 i = 0; i < SAVE_ARENAS_NUM; i++)
+    {
+        Arena* arena = C.arenas[i];
+        FileWrite(&file, arena, sizeof(Arena), 1);
+        FileWrite(&file, arena->base, arena->size, 1);
+    }
+
+    FileClose(&file);
+    L_INFO("Game state saved to %s", filename);
+    return true;
+}
+
+b8 LoadGameState(const char* filename)
+{
+    File file = FileOpen(filename, "rb");
+    if (!file.valid)
+    {
+        L_ERROR("Failed to open %s for loading", filename);
+        return false;
+    }
+
+    for (u8 i = 0; i < SAVE_ARENAS_NUM; i++)
+    {
+        Arena* arena = C.arenas[i];
+        Arena serialised_arena = {0};
+        FileRead(&file, &serialised_arena, sizeof(Arena), 1);
+
+        if (serialised_arena.size > arena->size)
+            ArenaResize(arena, serialised_arena.size);
+        cu_memcpy(arena, &serialised_arena, sizeof(Arena));
+        FileRead(&file, arena->base, arena->size, 1);
+    }
+
+    FileClose(&file);
+    L_INFO("Game state loaded from %s", filename);
+    return true;
+}
+
+void UpdateSaveSystem(void)
+{
+    b8 save_pressed = GetKeyState(KEY_F10) & KEY_STATE_PRESSED;
+    if (save_pressed)
+    {
+        SaveGameState("quicksave.cpf");
+    }
+
+    b8 load_pressed = GetKeyState(KEY_F12) & KEY_STATE_PRESSED;
+    if (load_pressed)
+    {
+        LoadGameState("quicksave.cpf");
+    }
+}

--- a/src/save.h
+++ b/src/save.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "file.h"
+#include "memory/arena.h"
+
+#define SAVE_ARENAS_NUM 3
+
+typedef struct SaveSystemInitInfo
+{
+    Arena* arenas[SAVE_ARENAS_NUM];
+} SaveSystemInitInfo;
+
+void InitSaveSystem(SaveSystemInitInfo* info);
+b8 SaveGameState(const char* filename);
+b8 LoadGameState(const char* filename);
+void UpdateSaveSystem(void);


### PR DESCRIPTION
You can now quick save the game by pressing `F10` and load your save with `F12`. There is currently only a single save slot. If you need more, you can possibly use replay system for additional 4 slots. Perhaps I'll one day extend it to have more slots, or to allow user to have a  Save/Load menu dialog where you can have many save slots and allow user to specify a name.